### PR TITLE
GitCommand Clone now support options

### DIFF
--- a/Bounce.Framework.Tests/Bounce.Framework.Tests.csproj
+++ b/Bounce.Framework.Tests/Bounce.Framework.Tests.csproj
@@ -97,7 +97,6 @@
     <Compile Include="Features\DescribeFeature.cs" />
     <Compile Include="GitCommandTests.cs" />
     <Compile Include="Integration\FrameworkTest.cs" />
-    <Compile Include="Integration\GitCommandTests.cs" />
     <Compile Include="NUnitTestsWithPartCoverTests.cs" />
     <Compile Include="RenameFileTests.cs" />
     <Compile Include="RenameDirectoryTests.cs" />

--- a/Bounce.Framework.Tests/GitCheckoutTest.cs
+++ b/Bounce.Framework.Tests/GitCheckoutTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Moq;
 using NUnit.Framework;
 
@@ -43,7 +44,7 @@ namespace Bounce.Framework.Tests {
             var gitRepo = new GitCheckout(parser.Object, dirs.Object, git.Object) {Repository = "repo"};
             gitRepo.Build(Bounce.Object);
 
-            git.Verify(g => g.Clone("repo", "dir", Log, Bounce.Object), Times.Once());
+            git.Verify(g => g.Clone("repo", "dir", null, Log, Bounce.Object), Times.Once());
         }
 
         [Test]
@@ -58,7 +59,7 @@ namespace Bounce.Framework.Tests {
             var gitRepo = new GitCheckout(parser.Object, dirs.Object, git.Object) {Repository = "repo", Directory = "path"};
             gitRepo.Build(Bounce.Object);
 
-            git.Verify(g => g.Clone("repo", "path", Log, Bounce.Object), Times.Once());
+            git.Verify(g => g.Clone("repo", "path", null, Log, Bounce.Object), Times.Once());
         }
 
         [Test]
@@ -81,6 +82,22 @@ namespace Bounce.Framework.Tests {
             var subPath = gitRepo.Files["test.txt"];
             Assert.That(subPath.Value, Is.EqualTo(@"dir\test.txt"));
             Assert.That(subPath.IsDependentOn(gitRepo));
+        }
+
+        [Test]
+        public void IfBranchIsProvidedShouldCloneWithBranchOptions() {
+            var git = new Mock<IGitCommand>();
+            var dirs = new Mock<IDirectoryUtils>();
+            var parser = new Mock<IGitRepoParser>();
+
+            parser.Setup(p => p.ParseCloneDirectoryFromRepoUri("repo")).Returns("dir");
+            dirs.Setup(d => d.DirectoryExists("dir")).Returns(false);
+
+            var gitRepo = new GitCheckout(parser.Object, dirs.Object, git.Object) { Repository = "repo", Directory = "path", Branch = "develop" };
+            gitRepo.Build(Bounce.Object);
+
+            var expectedOption = new Dictionary<string, string> { { "--branch", "develop" } };
+            git.Verify(g => g.Clone("repo", "path", expectedOption, Log, Bounce.Object), Times.Once());
         }
     }
 }

--- a/Bounce.Framework.Tests/GitCommandTests.cs
+++ b/Bounce.Framework.Tests/GitCommandTests.cs
@@ -19,7 +19,7 @@ namespace Bounce.Framework.Tests {
             bounceMock.Setup(_ => _.ShellCommand).Returns(shellCommandMock.Object);
 
             // act 
-            gitCommand.Clone("git@github.com:alexanderbeletsky/bounce.git", "currentDirectory", logMock.Object, bounceMock.Object);
+            gitCommand.Clone("git@github.com:alexanderbeletsky/bounce.git", "currentDirectory", null, logMock.Object, bounceMock.Object);
 
             // assert
             shellCommandMock.Verify(_ => _.ExecuteAndExpectSuccess("cmd" , "/C git clone git@github.com:alexanderbeletsky/bounce.git \"currentDirectory\""));
@@ -74,6 +74,44 @@ namespace Bounce.Framework.Tests {
 
             // assert
             shellCommandMock.Verify(_ => _.ExecuteAndExpectSuccess("cmd", "/C git tag MyTag"));
+        }
+
+        [Test]
+        public void Clone_WithOptions() {
+            // arrange
+            var logMock = new Mock<ILog>();
+            var bounceMock = new Mock<IBounce>();
+            var shellCommandMock = new Mock<IShellCommandExecutor>();
+            var gitCommand = new GitCommand();
+
+            bounceMock.Setup(_ => _.ShellCommand).Returns(shellCommandMock.Object);
+
+            var options = new Dictionary<string, string> { { "--branch", "develop" } };
+
+            // act 
+            gitCommand.Clone("git@github.com:alexanderbeletsky/bounce.git", "currentDirectory", options, logMock.Object, bounceMock.Object);
+
+            // assert
+            shellCommandMock.Verify(_ => _.ExecuteAndExpectSuccess("cmd", "/C git clone --branch develop git@github.com:alexanderbeletsky/bounce.git \"currentDirectory\""));
+        }
+
+        [Test]
+        public void Clone_WithSeveralOptions() {
+            // arrange
+            var logMock = new Mock<ILog>();
+            var bounceMock = new Mock<IBounce>();
+            var shellCommandMock = new Mock<IShellCommandExecutor>();
+            var gitCommand = new GitCommand();
+
+            bounceMock.Setup(_ => _.ShellCommand).Returns(shellCommandMock.Object);
+
+            var options = new Dictionary<string, string> { { "--branch", "develop" }, { "--origin", "myorig" } };
+
+            // act 
+            gitCommand.Clone("git@github.com:alexanderbeletsky/bounce.git", "currentDirectory", options, logMock.Object, bounceMock.Object);
+
+            // assert
+            shellCommandMock.Verify(_ => _.ExecuteAndExpectSuccess("cmd", "/C git clone --branch develop --origin myorig git@github.com:alexanderbeletsky/bounce.git \"currentDirectory\""));
         }
     }
 }

--- a/Bounce.Framework/GitCheckout.cs
+++ b/Bounce.Framework/GitCheckout.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace Bounce.Framework {
     public class GitCheckout : Task {
@@ -7,6 +9,8 @@ namespace Bounce.Framework {
         public Task<string> Repository;
         [Dependency]
         public Task<string> Directory;
+        [Dependency]
+        public Task<string> Branch;
 
         private IGitRepoParser GitRepoParser;
         private IDirectoryUtils DirectoryUtils;
@@ -23,11 +27,21 @@ namespace Bounce.Framework {
         public override void Build(IBounce bounce) {
             bounce.Log.Debug("pwd");
             bounce.Log.Debug(System.IO.Directory.GetCurrentDirectory());
+
             if (DirectoryUtils.DirectoryExists(WorkingDirectory)) {
                 GitCommand.Pull(WorkingDirectory, bounce.Log, bounce);
             } else {
-                GitCommand.Clone(Repository.Value, WorkingDirectory, bounce.Log, bounce);
+                var options = GetCommandOptions();
+                GitCommand.Clone(Repository.Value, WorkingDirectory, options, bounce.Log, bounce);
             }
+        }
+
+        private IDictionary<string, string> GetCommandOptions() {
+            if (Branch != null && Branch.Value != null) {
+                return new Dictionary<string, string> { { "--branch", Branch.Value } };
+            }
+
+            return null;
         }
 
         private string WorkingDirectory {

--- a/Bounce.Framework/GitCommand.cs
+++ b/Bounce.Framework/GitCommand.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Bounce.Framework {
     class GitCommand : IGitCommand {
@@ -11,10 +13,16 @@ namespace Bounce.Framework {
             }
         }
 
-        public void Clone(string repo, string directory, ILog log, IBounce bounce)
+        public void Clone(string repo, string directory, IDictionary<string, string> options,  ILog log, IBounce bounce)
         {
             log.Info("cloning git repo: {0}, into: {1}", repo, directory);
-            Git(bounce, @"clone {0} ""{1}""", repo, directory);
+
+            if (options == null) {
+                Git(bounce, @"clone {0} ""{1}""", repo, directory);
+            }
+            else {
+                Git(bounce, @"clone {0} {1} ""{2}""", options.ToOptionsString(), repo, directory);
+            }
         }
 
         public void Tag(string tag, bool force, IBounce bounce)
@@ -41,6 +49,12 @@ namespace Bounce.Framework {
             public void Dispose() {
                 Directory.SetCurrentDirectory(OldDirectory);
             }
+        }
+    }
+
+    static class GitOptionsExtentions {
+        public static string ToOptionsString(this IDictionary<string, string> options) {
+            return string.Join("", options.Select(o => string.Format("{0} {1} ", o.Key, o.Value))).Trim();
         }
     }
 }

--- a/Bounce.Framework/IGitCommand.cs
+++ b/Bounce.Framework/IGitCommand.cs
@@ -1,7 +1,9 @@
-﻿namespace Bounce.Framework {
+﻿using System.Collections.Generic;
+
+namespace Bounce.Framework {
     public interface IGitCommand {
         void Pull(string workingDirectory, ILog log, IBounce bounce);
-        void Clone(string repo, string directory, ILog log, IBounce bounce);
+        void Clone(string repo, string directory, IDictionary<string, string> options, ILog log, IBounce bounce);
         void Tag(string tag, bool force, IBounce bounce);
     }
 }


### PR DESCRIPTION
I need to be able to clone with particular branch, I've extened GitCommands to support that. Add some more test cases as well.

I've used simple Dictionary<> to be used as options argument. Could please take a look, if you have better (more flexible?) idea of such extention, please let me know :)
